### PR TITLE
Remove ES6 arrow function for building with UglifyJS.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2,9 +2,9 @@ const toArray = require('lodash/toArray');
 const getType = require('./getType');
 
 module.exports = function parse(str) {
-  return toArray(str).map(text => {
+  return toArray(str).map(function(text) {
     return {
-      text,
+      text: text,
       type: getType(text),
     };
   });


### PR DESCRIPTION
When importing this library into a project using [create-react-app](https://github.com/facebookincubator/create-react-app), I end up getting the following error when running `npm run build`:

```
static/js/main.4b40bb14.js from UglifyJs
Unexpected token: operator (>) [./~/emoji-tree/lib/parse.js:5,0][static/js/main.4b40bb14.js:18284,32]
```

It looks like it's related to an issue that the UglifyJS library (which currently ships with `create-react-app`) has with building modules that use ES6.

Hopefully this will be fixed inside UglifyJS in the near future (though this was [reported as an issue back in 2015](https://github.com/mishoo/UglifyJS2/issues/659) and it's still not fixed!). I love using ES6 myself, but it seems like the recommended approach is that we still need to transpile npm modules to ES5 for maximum compatibility.